### PR TITLE
Fix spelling in footer

### DIFF
--- a/sections/SectionFooter.tsx
+++ b/sections/SectionFooter.tsx
@@ -75,7 +75,7 @@ export default function SectionFooter(props) {
                 Terms of Service
               </a>
               <a className={styles.link} href="https://txt.dev/wwwjim/intdev-privacy-policy">
-                Prviacy Policy
+                Privacy Policy
               </a>
             </div>
           </div>


### PR DESCRIPTION
Fixed spelling of “Privacy Policy”